### PR TITLE
Limit results to past 5 months

### DIFF
--- a/assets/opstools/FCFActivityManager/controllers/crud1FCFActivity.js
+++ b/assets/opstools/FCFActivityManager/controllers/crud1FCFActivity.js
@@ -602,7 +602,8 @@ steal(
                         loadData: function () {
                             var _this = this;
 
-                            this.Model.findAll()
+                            var sixMonthsAgo = moment().subtract(5, 'months').format("YYYY-MM-DD");
+                            this.Model.findAll({ date: { '>': sixMonthsAgo }})
                                 .fail(function (err) {
                                     AD.error.log('crud1FCFActivity: Error loading Data', { error: err });
                                 })


### PR DESCRIPTION
Now that we have a few reporting cycles of data it is taking a very long time to access this tool. Since the most we will ever need is 4 months plus a little extra while they go in and adjust data while preparing reports 5 months back should be a good working range.