### PR TITLE
Limit Activity Manager data to 5 months

### DIFF
--- a/assets/opstools/FCFActivityManager/controllers/crud1FCFActivity.js
+++ b/assets/opstools/FCFActivityManager/controllers/crud1FCFActivity.js
@@ -601,7 +601,8 @@ steal(
                         loadData: function () {
                             var _this = this;
 
-                            this.Model.findAll()
+                            var fiveMonthsAgo = moment().subtract(5, 'months').format("YYYY-MM-DD");
+                            this.Model.findAll({ date: { '>': fiveMonthsAgo }})
                                 .fail(function (err) {
                                     AD.error.log('crud1FCFActivity: Error loading Data', { error: err });
                                 })


### PR DESCRIPTION
This reduces the amount of data loaded at launch to speed up the site. But users are only able to search based on a rolling 5 month period.